### PR TITLE
Fixed module declaration issue

### DIFF
--- a/hmsclient/client.go
+++ b/hmsclient/client.go
@@ -21,7 +21,7 @@ import (
     "strconv"
     "strings"
 
-    "git.apache.org/thrift.git/lib/go/thrift"
+    "github.com/apache/thrift/lib/go/thrift"
     "github.com/akolb1/gometastore/hmsclient/thrift/gen-go/hive_metastore"
 )
 

--- a/hmsclient/thrift/gen-go/hive_metastore/hive_metastore-consts.go
+++ b/hmsclient/thrift/gen-go/hive_metastore/hive_metastore-consts.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/hmsclient/thrift/gen-go/hive_metastore/hive_metastore.go
+++ b/hmsclient/thrift/gen-go/hive_metastore/hive_metastore.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)


### PR DESCRIPTION
When you try `go get github.com/akolb1/gometastore/hmsbench` you will get error

```
go get: git.apache.org/thrift.git@v0.15.0: parsing go.mod:
        module declares its path as: github.com/apache/thrift
                but was required as: git.apache.org/thrift.git
```